### PR TITLE
Fix parent child timetable switching

### DIFF
--- a/edupage_api/parent.py
+++ b/edupage_api/parent.py
@@ -9,7 +9,8 @@ class Parent(Module):
     @ModuleHelper.logged_in
     @ModuleHelper.is_parent
     def switch_to_child(self, child: Union[EduAccount, int]):
-        params = {"studentid": child.person_id if type(child) == EduAccount else child}
+        child_id = child.person_id if isinstance(child, EduAccount) else child
+        params = {"studentid": child_id}
 
         url = f"https://{self.edupage.subdomain}.edupage.org/login/switchchild"
         response = self.edupage.session.get(url, params=params)
@@ -18,6 +19,8 @@ class Parent(Module):
             raise InvalidChildException(
                 f"{response.text}: Invalid child selected! (not your child?)"
             )
+
+        self.edupage._selected_child_id = int(child_id)
 
     @ModuleHelper.logged_in
     @ModuleHelper.is_parent
@@ -32,3 +35,5 @@ class Parent(Module):
 
         if "EdupageLoginFailed" in response.url:
             raise UnknownServerError()
+
+        self.edupage._selected_child_id = None

--- a/edupage_api/timetables.py
+++ b/edupage_api/timetables.py
@@ -279,6 +279,18 @@ class Timetables(Module):
 
     @ModuleHelper.logged_in
     def get_my_timetable(self, date: date) -> Optional[Timetable]:
+        selected_child_id = getattr(self.edupage, "_selected_child_id", None)
+
+        if selected_child_id is not None:
+            student = People(self.edupage).get_student(selected_child_id)
+
+            if student is None:
+                raise MissingDataException(
+                    f"Selected child with ID {selected_child_id} was not found."
+                )
+
+            return self.get_timetable(student, date)
+
         plan = self.__get_date_plan(date)
         return self.__parse_timetable(plan)
 

--- a/examples/timetables.py
+++ b/examples/timetables.py
@@ -6,6 +6,28 @@ edupage = Edupage()
 edupage.login_auto("Username (or e-mail)", "Password")
 
 # My timetable
+# Leave as None to keep the original get_my_timetable() behavior.
+# Set a full student name to explicitly switch to a specific child.
+student_name = None
+# student_name = "Alžbeta Výborná"
+
+if student_name is not None:
+    students = edupage.get_students() or []
+
+    student = next(
+        (student for student in students if student.name == student_name),
+        None,
+    )
+
+    if student is None:
+        available_students = [student.name for student in students]
+        raise RuntimeError(
+            f"Student {student_name!r} was not found. "
+            f"Available students: {available_students}"
+        )
+
+    edupage.switch_to_child(student)
+
 date = datetime.date(2024, 6, 12)
 timetable = edupage.get_my_timetable(date)
 


### PR DESCRIPTION
## Summary

Fix parent account timetable switching when working with multiple children.

## Problem

`switch_to_child()` used an exact type comparison:

```python
type(child) == EduAccount
```

This does not work correctly when an `EduStudent` instance is passed, even though `EduStudent` is a subclass of `EduAccount`.

Additionally, `get_my_timetable()` did not retain information about the explicitly selected child and continued using the legacy timetable path.

## Changes

- Use `isinstance(child, EduAccount)` in `switch_to_child()`.
- Store the selected child ID after a successful child switch.
- Clear the selected child ID when switching back to the parent.
- When a child is explicitly selected, `get_my_timetable()` resolves that student and uses the newer `get_timetable(student, date)` implementation.
- Add an example demonstrating timetable retrieval for a selected child.

## Testing

Tested with a parent account containing multiple children. Switching between the children now returns the correct timetable for each selected child.

Addresses #106.

Related to #95: the newer timetable path also avoids the legacy `/gcall` request that can fail for some accounts. This PR does not completely fix #95 because `get_my_timetable()` without an explicitly selected child still uses the legacy implementation.